### PR TITLE
Pre-commit hooks

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+ignore = E203, E266, E501, W503, F403, F401
+max-line-length = 120
+max-complexity = 18
+select = B,C,E,F,W,T4,B9
+exclude = 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     - id: requirements-txt-fixer
     - id: end-of-file-fixer
     - id: name-tests-test
+      name: Test files start with test_
       args: ['--django']
 -   repo: https://github.com/ambv/black
     rev: 20.8b1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v3.4.0
+    hooks:
+    - id: check-added-large-files
+    - id: check-merge-conflict
+    - id: requirements-txt-fixer
+    - id: end-of-file-fixer
+    - id: name-tests-test
+      args: ['--django']
+-   repo: https://github.com/ambv/black
+    rev: 20.8b1
+    hooks:
+    - id: black
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.9.0
+    hooks:
+    - id: flake8

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing
 
-We welcome external contributions! Please find instructionsn on how to contribute below.
+We welcome your contributions! Please find instructionsn on how to contribute below.
 
 ## Pre-commit hooks
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,7 @@
+# Contributing
+
+We welcome external contributions! Please find instructionsn on how to contribute below.
+
+## Pre-commit hooks
+
+In order to ensure code quality, we provide a set of pre-commit hooks that can be run before comitting. These hooks are a bunch of checks that will be run before each commit. To install them, simply `pip install pre-commit` and run `pre-commit install` in your local copy of the repository.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[tool.black]
+line-length = 120
+include = '\.pyi?$'
+exclude = '''
+/(
+    \.git
+  | \.hg
+  | \.mypy_cache
+  | \.tox
+  | \.venv
+  | _build
+  | buck-out
+  | build
+  | dist
+)/
+'''


### PR DESCRIPTION
This pull request introduces pre-commit hooks that should help maintain code quality over time. Among other checks, it includes:
* Flake8 to check PEP8 compatibility
* [Black](https://black.readthedocs.io/en/stable/) to automatically reformat the code so that it's readable and to satisfy Flake8

Files will be progressively adapted as they are committed. I can also run Black on some directories in the codebase to make everything compliant if you'd like.