### PR TITLE
WIP: run_wizard without argparse

### DIFF
--- a/haven/haven_wizard.py
+++ b/haven/haven_wizard.py
@@ -291,7 +291,7 @@ class CheckpointManager:
         else:
             return None
 
-    def save_model(state_dict):
+    def save_model(self, state_dict):
         hu.torch_save(os.path.join(self.savedir, "model.pth"), state_dict)
 
     def get_epoch(self):
@@ -315,7 +315,7 @@ class CheckpointManager:
         if not isinstance(images, list):
             images = [images]
 
-        for im in images:
+        for i, im in enumerate(images):
             hu.save_image(os.path.join(self.savedir, "images", f"{i}.jpg"), im)
 
 


### PR DESCRIPTION
`run_wizard_no_argparse` allows users to specify whatever args they want in their trainval script

this is more functional and flexible, the only issue is currently the code that calls `jm.launch_menu` uses a hard-coded command that takes in `--exp-id` and `--savedir-base` so those two arguments are required in any user's trainval. 

other changes
- isort imports
- fix missing `self` in class method
- fix missing `i` in iteration

TODO
- run tests to make sure that functionality is unchanged