### PR TITLE
Remove deprecated sklearn from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,6 @@ setup(
         "scikit-image>=0.0",
         "scikit-learn>=0.0",
         "scipy>=0.0",
-        "sklearn>=0.0",
         "torch>=0.0",
         "torchvision>=0.0",
         "notebook >= 4.0",


### PR DESCRIPTION
```
      The 'sklearn' PyPI package is deprecated, use 'scikit-learn'
      rather than 'sklearn' for pip commands.

      Here is how to fix this error in the main use cases:
      - use 'pip install scikit-learn' rather than 'pip install sklearn'
      - replace 'sklearn' by 'scikit-learn' in your pip requirements files
        (requirements.txt, setup.py, setup.cfg, Pipfile, etc ...)
      - if the 'sklearn' package is used by one of your dependencies,
        it would be great if you take some time to track which package uses
        'sklearn' instead of 'scikit-learn' and report it to their issue tracker
      - as a last resort, set the environment variable
        SKLEARN_ALLOW_DEPRECATED_SKLEARN_PACKAGE_INSTALL=True to avoid this error

      More information is available at
https://github.com/scikit-learn/sklearn-pypi-package
```